### PR TITLE
Do not consider invalid requests as an error

### DIFF
--- a/ddtrace_graphql/__init__.py
+++ b/ddtrace_graphql/__init__.py
@@ -25,10 +25,11 @@ with require_modules(required_modules) as missing_modules:
         from .patch import (
             TracedGraphQLSchema,
             patch, unpatch, traced_graphql,
-            TYPE, SERVICE, QUERY, ERRORS, INVALID, RES
+            TYPE, SERVICE, QUERY, ERRORS, INVALID, RES, DATA_EMPTY
         )
         __all__ = [
             'TracedGraphQLSchema',
             'patch', 'unpatch', 'traced_graphql',
-            'TYPE', 'SERVICE', 'QUERY', 'ERRORS', 'INVALID', 'RES'
+            'TYPE', 'SERVICE', 'QUERY', 'ERRORS', 'INVALID',
+            'RES', 'DATA_EMPTY',
         ]


### PR DESCRIPTION
If graphql request result contains validation errors resp. is marked as
invalid, do not consider this as an error. From the POV of graphql
server/service this is client error.

Added metric to indicate that the result data is empty.

http://facebook.github.io/graphql/October2016/#sec-Errors