### PR TITLE
Add ability to override default span kwargs

### DIFF
--- a/ddtrace_graphql/__init__.py
+++ b/ddtrace_graphql/__init__.py
@@ -25,11 +25,11 @@ with require_modules(required_modules) as missing_modules:
         from .patch import (
             TracedGraphQLSchema,
             patch, unpatch, traced_graphql,
-            TYPE, SERVICE, QUERY, ERRORS, INVALID, RES, DATA_EMPTY
+            TYPE, SERVICE, QUERY, ERRORS, INVALID, RES_NAME, DATA_EMPTY
         )
         __all__ = [
             'TracedGraphQLSchema',
             'patch', 'unpatch', 'traced_graphql',
             'TYPE', 'SERVICE', 'QUERY', 'ERRORS', 'INVALID',
-            'RES', 'DATA_EMPTY',
+            'RES_NAME', 'DATA_EMPTY',
         ]

--- a/ddtrace_graphql/patch.py
+++ b/ddtrace_graphql/patch.py
@@ -26,10 +26,10 @@ logger = logging.getLogger(__name__)
 _graphql = graphql.graphql
 
 TYPE = 'graphql'
-QUERY = 'graphql.query'
-ERRORS = 'graphql.errors'
-INVALID = 'graphql.invalid'
-DATA_EMPTY = 'graphql.data_empty'
+QUERY = 'query'
+ERRORS = 'errors'
+INVALID = 'invalid'
+DATA_EMPTY = 'data_empty'
 RES_NAME = 'graphql.graphql'
 #
 SERVICE_ENV_VAR = 'DDTRACE_GRAPHQL_SERVICE'

--- a/ddtrace_graphql/patch.py
+++ b/ddtrace_graphql/patch.py
@@ -5,7 +5,9 @@ https://github.com/graphql-python/graphql-core
 """
 
 # stdlib
+import functools
 import logging
+import os
 import re
 
 # 3p
@@ -24,12 +26,14 @@ logger = logging.getLogger(__name__)
 _graphql = graphql.graphql
 
 TYPE = 'graphql'
-SERVICE = 'graphql'
 QUERY = 'graphql.query'
 ERRORS = 'graphql.errors'
 INVALID = 'graphql.invalid'
 DATA_EMPTY = 'graphql.data_empty'
-RES = 'graphql.graphql'
+RES_NAME = 'graphql.graphql'
+#
+SERVICE_ENV_VAR = 'DDTRACE_GRAPHQL_SERVICE'
+SERVICE = 'graphql'
 
 
 class TracedGraphQLSchema(graphql.GraphQLSchema):
@@ -42,13 +46,16 @@ class TracedGraphQLSchema(graphql.GraphQLSchema):
         super(TracedGraphQLSchema, self).__init__(*args, **kwargs)
 
 
-def patch():
+def patch(span_kwargs=None):
     """
     Monkeypatches graphql-core library to trace graphql calls execution.
     """
     logger.debug('Patching `graphql.graphql` function.')
-    wrapt.wrap_function_wrapper(graphql, 'graphql', _traced_graphql)
 
+    def wrapper(func, _, args, kwargs):
+        return _traced_graphql(func, args, kwargs, span_kwargs=span_kwargs)
+
+    wrapt.wrap_function_wrapper(graphql, 'graphql', wrapper)
 
 def unpatch():
     logger.debug('Unpatching `graphql.graphql` function.')
@@ -62,7 +69,7 @@ def _resolve_query_res(query):
     return re.split('[({]', query, 1)[0].strip() or query
 
 
-def _traced_graphql(func, args, kwargs):
+def _traced_graphql(func, args, kwargs, span_kwargs=None):
     """
     Wrapper for graphql.graphql function.
     """
@@ -86,12 +93,15 @@ def _traced_graphql(func, args, kwargs):
     if not tracer.enabled:
         return func(*args, **kwargs)
 
-    with tracer.trace(
-        RES,
-        span_type=TYPE,
-        service=SERVICE,
-        resource=_resolve_query_res(query)
-    ) as span:
+    _span_kwargs = {
+        'name': RES_NAME,
+        'span_type': TYPE,
+        'service': os.getenv(SERVICE_ENV_VAR, SERVICE),
+        'resource': _resolve_query_res(query)
+    }
+    _span_kwargs.update(span_kwargs or {})
+
+    with tracer.trace(**_span_kwargs) as span:
         span.set_tag(QUERY, query)
         result = None
         try:
@@ -117,5 +127,5 @@ def _traced_graphql(func, args, kwargs):
                     span.error = 1
 
 
-def traced_graphql(*args, **kwargs):
-    return _traced_graphql(_graphql, args, kwargs)
+def traced_graphql(*args, _span_kwargs=None, **kwargs):
+    return _traced_graphql(_graphql, args, kwargs, span_kwargs=_span_kwargs)


### PR DESCRIPTION
* span_kwargs override default kwargs for tracer.trace method.
It's possible to pass it to patch method and also to traced_graphql

* DDTRACE_GRAPHQL_SERVICE env variable can override default value for
SERVICE