### PR TITLE
Unpatch was missing a log message when unpatching `execute_and_validate`

### DIFF
--- a/ddtrace_graphql/patch.py
+++ b/ddtrace_graphql/patch.py
@@ -44,4 +44,5 @@ def patch(span_kwargs=None, span_callback=None, ignore_exceptions=()):
 def unpatch():
     logger.debug("Unpatching `graphql.graphql` function.")
     unwrap(graphql, "graphql")
+    logger.debug("Unpatching `graphql.backend.core.execute_and_validate` function.")
     unwrap(graphql.backend.core, "execute_and_validate")


### PR DESCRIPTION
`unpatch` function was missing a log statment when unpatching here:
https://github.com/beezz/ddtrace-graphql/blob/354ca60eea95d6add8928e84696a16fce127c50a/ddtrace_graphql/patch.py#L47