### PR TITLE
Fix error when using with graphql-ws

### DIFF
--- a/ddtrace_graphql/base.py
+++ b/ddtrace_graphql/base.py
@@ -74,31 +74,35 @@ def traced_graphql_wrapped(
             if result is not None:
 
                 span.error = 0
-                if result.errors:
-                    span.set_tag(
-                        ERRORS,
-                        utils.format_errors(result.errors))
-                    span.set_tag(
-                        ddtrace_errors.ERROR_STACK,
-                        utils.format_errors_traceback(result.errors))
-                    span.set_tag(
-                        ddtrace_errors.ERROR_MSG,
-                        utils.format_errors_msg(result.errors))
-                    span.set_tag(
-                        ddtrace_errors.ERROR_TYPE,
-                        utils.format_errors_type(result.errors))
+                if hasattr(result, 'errors'):
+                    if result.errors:
+                        span.set_tag(
+                            ERRORS,
+                            utils.format_errors(result.errors))
+                        span.set_tag(
+                            ddtrace_errors.ERROR_STACK,
+                            utils.format_errors_traceback(result.errors))
+                        span.set_tag(
+                            ddtrace_errors.ERROR_MSG,
+                            utils.format_errors_msg(result.errors))
+                        span.set_tag(
+                            ddtrace_errors.ERROR_TYPE,
+                            utils.format_errors_type(result.errors))
 
-                    span.error = int(utils.is_server_error(
-                        result,
-                        ignore_exceptions,
-                    ))
+                        span.error = int(utils.is_server_error(
+                            result,
+                            ignore_exceptions,
+                        ))
 
-                span.set_metric(
-                    CLIENT_ERROR,
-                    int(bool(not span.error and result.errors))
-                )
-                span.set_metric(INVALID, int(result.invalid))
-                span.set_metric(DATA_EMPTY, int(result.data is None))
+                    span.set_metric(
+                        CLIENT_ERROR,
+                        int(bool(not span.error and result.errors))
+                    )
+
+                if hasattr(result, 'invalid'):
+                    span.set_metric(INVALID, int(result.invalid))
+                if hasattr(result, 'data'):
+                    span.set_metric(DATA_EMPTY, int(result.data is None))
 
             if span_callback is not None:
                 span_callback(result=result, span=span)


### PR DESCRIPTION
[graphql-ws](https://github.com/graphql-python/graphql-ws) is graphql-python's official implementation of websockets for supporting GraphQL Subscriptions.

When executing subscriptions with `graphql-core` v2, the result of subscription execution is an Rx Observable, not an ExecutionResult. So trying to use `graphql-ws` alongside this patch results in the following error, which can be traced back to `base.py` L77:

```
AttributeError: 'AnonymousObservable' object has no attribute 'errors'
```

This PR just adds hasattr checks when attaching tags to the span so that when result is a Subscription, tag setting is skipped. With this change, subscriptions execute without error, and are even recorded in data dog.